### PR TITLE
Allow for multiple versions

### DIFF
--- a/pkgs/foundryvtt/default.nix
+++ b/pkgs/foundryvtt/default.nix
@@ -19,6 +19,13 @@
 let
   nodejs = nodejs-18_x;
   foundryvtt-deps = callPackage ./foundryvtt-deps { };
+
+  foundry-version-hashes = version: {
+    "10.291" = "0j9xjqqpl8maggi45wskajxl2c9jlcl8pw1cx6nmgbcj5w4c5xrf";
+    "11.301" = "1r5bqhd3cfq3yvzb1yybgvysbhbjqv6d2f768b063fdsdq2ixi2s";
+  }.${version} or (
+    lib.warn "Unknown foundryvtt version: '${version}'. Please update foundry-version-hashes." lib.fakeHash
+  );
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "foundryvtt";
@@ -31,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = requireFile {
     name = "FoundryVTT-${finalAttrs.majorVersion}.${finalAttrs.build}.zip";
-    sha256 = "1r5bqhd3cfq3yvzb1yybgvysbhbjqv6d2f768b063fdsdq2ixi2s";
+    sha256 = foundry-version-hashes "${finalAttrs.majorVersion}.${finalAttrs.build}";
     url = "https://foundryvtt.com";
   };
 

--- a/pkgs/foundryvtt/default.nix
+++ b/pkgs/foundryvtt/default.nix
@@ -23,6 +23,7 @@ let
   foundry-version-hashes = version: {
     "10.291" = "0j9xjqqpl8maggi45wskajxl2c9jlcl8pw1cx6nmgbcj5w4c5xrf";
     "11.301" = "1r5bqhd3cfq3yvzb1yybgvysbhbjqv6d2f768b063fdsdq2ixi2s";
+    "11.302" = "1myhhfxm0qa40ymx3gznwmh0xwl2kymqcgz777dks42j2wdy1zci";
   }.${version} or (
     lib.warn "Unknown foundryvtt version: '${version}'. Please update foundry-version-hashes." lib.fakeHash
   );
@@ -34,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   majorVersion = "11";
   minorVersion = "0";
   patchVersion = "0";
-  build = "301";
+  build = "302";
 
   src = requireFile {
     name = "FoundryVTT-${finalAttrs.majorVersion}.${finalAttrs.build}.zip";


### PR DESCRIPTION
I added in my own repository the ability for the flake to handle multiple versions via `overrideAttrs`. It obviously requires a hash for each version, so I've added in all the ones I've had access to.

This might cause issues if you need a different setup script for each version... But as far as I could tell there was little that would cause an issue at the moment.

Don't know if you want this, but thought I would submit a PR in case you do!