### PR TITLE
add: foundry 11.308

### DIFF
--- a/pkgs/foundryvtt/default.nix
+++ b/pkgs/foundryvtt/default.nix
@@ -28,6 +28,7 @@ let
     "11.305" = "1m2zsw9ypah109qj6nkfh3aa13n35mbh2v5g4r26vsbx3mk8azy4";
     "11.306" = "15a5pxc37rv898gn5d1f8dv59j57r3nxqdw10mj4c5cbjly438x0";
     "11.307" = "0k5qkmf1kk01227ads3bh7bgkrvjhjhjbwp6hkl58zdm166dikah";
+    "11.308" = "04jckd3i81a3jdq86cqp7s6b3gpsx9d1q8sbcca4fzk37yr2c53c";
   }.${version} or (
     lib.warn "Unknown foundryvtt version: '${version}'. Please update foundry-version-hashes." lib.fakeHash
   );
@@ -39,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   majorVersion = "11";
   minorVersion = "0";
   patchVersion = "0";
-  build = "307";
+  build = "308";
 
   src = requireFile {
     name = "FoundryVTT-${finalAttrs.majorVersion}.${finalAttrs.build}.zip";


### PR DESCRIPTION
I started working on updated to 11.308, but came across a problem (it's not a simple new hash).

Creating this as a draft PR in case anyone has the time to look at it. I'm not experienced enough to know how to fix these node issues - presumably it's trying to get this check-disk-space module from the registry which isn't possible during the installation phase, so perhaps an update to the node dependencies is needed?

```
npm ERR! request to https://registry.npmjs.org/check-disk-space failed: cache mode is 'only-if-cached' but no cached response is available.

npm ERR! A complete log of this run can be found in:
npm ERR!     /build/.npm/_logs/2023-09-02T15_52_31_674Z-debug-0.log
```