### PR TITLE
Replace pngout with oxipng

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
 
   outputs =
-    inputs@{ self, nixpkgs, ... }:
+    { self, nixpkgs, ... }:
     let
       lib = nixpkgs.lib;
 
@@ -31,16 +31,12 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "pngout" ];
           };
 
           mkFoundry =
             attrs:
-            (pkgs.callPackage ./pkgs/foundryvtt {
-              pngout =
-                if pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64 then pkgs.pkgsx86_64Darwin.pngout else pkgs.pngout;
-            }).overrideAttrs
-              (old: old // attrs);
+              (pkgs.callPackage ./pkgs/foundryvtt {})
+                .overrideAttrs (old: old // attrs);
         in
         {
           foundryvtt = mkFoundry { };

--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,7 @@
       packages = forAllSystems (
         system:
         let
-          pkgs = import nixpkgs {
-            inherit system;
-          };
-
+          pkgs = nixpkgs.legacyPackages.${system};
           mkFoundry =
             attrs:
               (pkgs.callPackage ./pkgs/foundryvtt {})

--- a/pkgs/foundryvtt/default.nix
+++ b/pkgs/foundryvtt/default.nix
@@ -8,11 +8,11 @@
   gzip,
   zstd,
   brotli,
-  pngout,
+  oxipng,
   stdenv,
   writeScript,
   nodejs,
-  usePngout ? true,
+  useOxipng ? true,
 }:
 
 let
@@ -33,7 +33,7 @@ let
         inherit name;
         value =
           foundry-version-hashes.${name}
-            or (builtins.abort "Unknow  n FoundryVTT version: '${attrs.version}'. Please run the update script.");
+            or (builtins.abort "Unknown FoundryVTT version: '${attrs.version}'. Please run the update script.");
       }
     else if (attrs.majorVersion or null) == null then
       lib.warn
@@ -166,12 +166,12 @@ let
 
         ln -s "$foundryvtt/public" "$out/public"
 
-        # Run PNG images through `pngout` if it’s available.
+        # Run PNG images through `oxipng` if it's enabled.
+        # could add "-o max" and "--zopfli" to increase compression power
+        # --interlace 0 or 1 to dis-/enable interlacing
         ${
-          if usePngout then
-            ''
-              find $foundryvtt/public -name '*.png' -exec ${pngout}/bin/pngout {} -k1 -y \;
-            ''
+          if useOxipng then
+            "${oxipng}/bin/oxipng $foundryvtt/public/**/*.png -s"
           else
             ""
         }


### PR DESCRIPTION
Oxipng is in my experience faster and better at compression than similar tools, in addition to being fully FOSS

As mentioned in the comment, there are flags that can be set to change desired compression level; for now I've set it to default with stripped metadata, I recommend checking the options out though