### PR TITLE
fix: remove deprecated `lib.mdDoc` call

### DIFF
--- a/modules/foundryvtt/default.nix
+++ b/modules/foundryvtt/default.nix
@@ -90,7 +90,7 @@ in
       dataDir = mkOption {
         type = types.str;
         default = "/var/lib/foundryvtt";
-        description = lib.mdDoc ''
+        description = ''
           The path where Foundry keeps its config, data, and logs.
         '';
       };


### PR DESCRIPTION
Without this removal flake is unusable on the actual unstable nixpkgs.

With this - I can use it even with nixpkgs override. You can test it by replacing:

```nix
    # In the inputs section
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

    foundryvtt = {
      url = "github:ffloyd/nix-foundryvtt";
      inputs.nixpkgs.follows = "nixpkgs";
    }
```

And thank you for keeping the project alive! It's still the best tool for adding Foundry VTT to NixOS!